### PR TITLE
bug_fix: ansible.errors not imported

### DIFF
--- a/action_plugins/copyv.py
+++ b/action_plugins/copyv.py
@@ -24,6 +24,7 @@ import os
 import tempfile
 
 from ansible import constants as C
+from ansible import errors
 from ansible.parsing.vault import VaultLib
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean


### PR DESCRIPTION
I was using this action plugin in my ansible module and ran into an error. This PR is to fix that bug
